### PR TITLE
Add Double Pinch modifier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,11 @@ let package = Package(
     products: [
         .library(name: "DoublePinch", targets: ["DoublePinch"]),
     ],
+    dependencies: [
+        .package(path: "TappableButton"),
+    ],
     targets: [
-        .target(name: "DoublePinch"),
+        .target(name: "DoublePinch", dependencies: ["TappableButton"]),
+        .testTarget(name: "DoublePinchTests", dependencies: ["DoublePinch"]),
     ]
 )

--- a/Sources/DoublePinch/DoublePinch.swift
+++ b/Sources/DoublePinch/DoublePinch.swift
@@ -1,10 +1,108 @@
+//
+//  DoublePinch.swift
+//  DoublePinch
+//
+
+import os
 import SwiftUI
+import TappableButton
+
+public struct DoublePinchMode: OptionSet, Sendable {
+    
+    public let rawValue: UInt
+    
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+    
+    public static let accessibilityQuickAction = DoublePinchMode(rawValue: 1 << 0)
+    
+    @available(watchOS 11.0, *)
+    public static let doubleTapGesture = DoublePinchMode(rawValue: 1 << 1)
+    
+    public static var all: DoublePinchMode {
+        if #available(watchOS 11.0, *), DoublePinchMode.isDoubleTapGestureSupported {
+            [.doubleTapGesture, .accessibilityQuickAction]
+        } else {
+            .accessibilityQuickAction
+        }
+    }
+    
+    static var isDoubleTapGestureSupported: Bool { // AKA isSeries9OrNewer
+        // https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt
+        guard let firstModelDigit = Int(String(describing: model.first)) else {
+            return false
+        }
+        return firstModelDigit >= 7
+    }
+    
+    private static var model: String {
+        var sysinfo = utsname()
+        uname(&sysinfo)
+        let machineMirror = Mirror(reflecting: sysinfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        return identifier
+    }
+}
+
+private let log = Logger(subsystem: "com.doublepinch", category: "DoublePinchModifier")
 
 extension Button {
     
-    nonisolated public func doublePinch(action: @escaping @MainActor () -> Void) -> some View {
-        accessibilityQuickAction(style: .outline) {
-            SwiftUI.Button("Magic Pinch", action: action)
+    @MainActor
+    public func doublePinch(_ mode: DoublePinchMode = .all) -> some View {
+        let modifier = DoublePinchViewModifier(mode: mode) {
+            guard let _action else {
+                log.fault(
+                    """
+                    No action has been found for the double pinch modifier. Please file an issue on GitHub.
+                    https://github.com/superturboryan/DoublePinch/issues
+                    
+                    Workaround: View/accessibilityQuickAction directly.
+                    """
+                )
+                return
+            }
+            MainActor.assumeIsolated(_action)
+        }
+        
+        return self.modifier(modifier)
+    }
+}
+
+private struct DoublePinchViewModifier: ViewModifier {
+    
+    let mode: DoublePinchMode
+    let action: @MainActor () -> Void
+    
+    init(mode: DoublePinchMode, action: @escaping @MainActor () -> Void) {
+        self.mode = mode
+        self.action = action
+    }
+    
+    public func body(content: Content) -> some View {
+        content.accessibilityQuickAction(
+            style: .outline,
+            isActive: .constant(mode.contains(.accessibilityQuickAction))
+        ) {
+            Button("Primary action", action: action)
+        }
+        .modifier(HandGestureShortcutModifier(mode: mode))
+    }
+}
+
+private struct HandGestureShortcutModifier: ViewModifier {
+    
+    let mode: DoublePinchMode
+    
+    public func body(content: Content) -> some View {
+        if #available(watchOS 11.0, *) {
+            content.handGestureShortcut(.primaryAction, isEnabled: mode.contains(.doubleTapGesture))
+        } else {
+            content
         }
     }
 }

--- a/Sources/DoublePinch/DoublePinch.swift
+++ b/Sources/DoublePinch/DoublePinch.swift
@@ -3,7 +3,7 @@
 //  DoublePinch
 //
 
-import os
+import OSLog
 import SwiftUI
 import TappableButton
 

--- a/Sources/DoublePinch/DoublePinch.swift
+++ b/Sources/DoublePinch/DoublePinch.swift
@@ -41,7 +41,7 @@ extension Button {
     @MainActor
     public func doublePinch(_ mode: DoublePinchMode = DoublePinchMode.automatic) -> some View {
         let modifier = DoublePinchViewModifier(mode: mode) {
-            guard let _action else {
+            if !_performAction() {
                 log.fault(
                     """
                     No action has been found for the double pinch modifier. Please file an issue on GitHub.
@@ -50,9 +50,7 @@ extension Button {
                     Workaround: Use View/accessibilityQuickAction directly.
                     """
                 )
-                return
             }
-            MainActor.assumeIsolated(_action)
         }
         
         return self.modifier(modifier)

--- a/Sources/DoublePinch/DoublePinch.swift
+++ b/Sources/DoublePinch/DoublePinch.swift
@@ -7,53 +7,12 @@ import os
 import SwiftUI
 import TappableButton
 
-public struct DoublePinchMode: OptionSet, Sendable {
-    
-    public let rawValue: UInt
-    
-    public init(rawValue: UInt) {
-        self.rawValue = rawValue
-    }
-    
-    public static let accessibilityQuickAction = DoublePinchMode(rawValue: 1 << 0)
-    
-    @available(watchOS 11.0, *)
-    public static let doubleTapGesture = DoublePinchMode(rawValue: 1 << 1)
-    
-    public static var all: DoublePinchMode {
-        if #available(watchOS 11.0, *), DoublePinchMode.isDoubleTapGestureSupported {
-            [.doubleTapGesture, .accessibilityQuickAction]
-        } else {
-            .accessibilityQuickAction
-        }
-    }
-    
-    static var isDoubleTapGestureSupported: Bool { // AKA isSeries9OrNewer
-        // https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt
-        guard let firstModelDigit = Int(String(describing: model.first)) else {
-            return false
-        }
-        return firstModelDigit >= 7
-    }
-    
-    private static var model: String {
-        var sysinfo = utsname()
-        uname(&sysinfo)
-        let machineMirror = Mirror(reflecting: sysinfo.machine)
-        let identifier = machineMirror.children.reduce("") { identifier, element in
-            guard let value = element.value as? Int8, value != 0 else { return identifier }
-            return identifier + String(UnicodeScalar(UInt8(value)))
-        }
-        return identifier
-    }
-}
-
 private let log = Logger(subsystem: "com.doublepinch", category: "DoublePinchModifier")
 
 extension Button {
     
     @MainActor
-    public func doublePinch(_ mode: DoublePinchMode = .all) -> some View {
+    public func doublePinch(_ mode: DoublePinchMode = DoublePinchMode.automatic) -> some View {
         let modifier = DoublePinchViewModifier(mode: mode) {
             guard let _action else {
                 log.fault(
@@ -61,7 +20,7 @@ extension Button {
                     No action has been found for the double pinch modifier. Please file an issue on GitHub.
                     https://github.com/superturboryan/DoublePinch/issues
                     
-                    Workaround: View/accessibilityQuickAction directly.
+                    Workaround: Use View/accessibilityQuickAction directly.
                     """
                 )
                 return
@@ -86,7 +45,7 @@ private struct DoublePinchViewModifier: ViewModifier {
     public func body(content: Content) -> some View {
         content.accessibilityQuickAction(
             style: .outline,
-            isActive: .constant(mode.contains(.accessibilityQuickAction))
+            isActive: .constant(mode == .accessibilityQuickAction)
         ) {
             Button("Primary action", action: action)
         }
@@ -100,7 +59,7 @@ private struct HandGestureShortcutModifier: ViewModifier {
     
     public func body(content: Content) -> some View {
         if #available(watchOS 11.0, *) {
-            content.handGestureShortcut(.primaryAction, isEnabled: mode.contains(.doubleTapGesture))
+            content.handGestureShortcut(.primaryAction, isEnabled: mode == .doubleTapGesture)
         } else {
             content
         }

--- a/Sources/DoublePinch/DoublePinch.swift
+++ b/Sources/DoublePinch/DoublePinch.swift
@@ -68,23 +68,12 @@ private struct DoublePinchViewModifier: ViewModifier {
     }
     
     public func body(content: Content) -> some View {
-        content.accessibilityQuickAction(
-            style: .outline,
-            isActive: .constant(mode == .accessibilityQuickAction)
-        ) {
-            Button("Primary action", action: action)
-        }
-        .modifier(HandGestureShortcutModifier(mode: mode))
-    }
-}
-
-private struct HandGestureShortcutModifier: ViewModifier {
-    
-    let mode: DoublePinchMode
-    
-    public func body(content: Content) -> some View {
-        if #available(watchOS 11.0, *) {
-            content.handGestureShortcut(.primaryAction, isEnabled: mode == .doubleTapGesture)
+        if #available(watchOS 11.0, *), mode == .doubleTapGesture {
+            content.handGestureShortcut(.primaryAction)
+        } else if mode == .accessibilityQuickAction {
+            content.accessibilityQuickAction(style: .outline) {
+                Button("Primary action", action: action)
+            }
         } else {
             content
         }

--- a/Sources/DoublePinch/DoublePinch.swift
+++ b/Sources/DoublePinch/DoublePinch.swift
@@ -11,6 +11,33 @@ private let log = Logger(subsystem: "com.doublepinch", category: "DoublePinchMod
 
 extension Button {
     
+    /// Adds a double-pinch gesture to the button, enabling actions to be triggered based on the specified mode.
+    ///
+    /// Use this modifier to configure a `Button` to respond to a double-pinch gesture, such as when an
+    /// accessibility quick action or the newer Double Tap gesture is triggered. The action associated
+    /// with the button will be executed when the double-pinch gesture is recognized.
+    ///
+    /// - Parameters:
+    ///   - mode: The mode defining the types of double-pinch actions to handle. Defaults to `.automatic`,
+    ///     which determines the most appropriate mode for the double-tap gesture.
+    ///
+    /// - Returns: A view modified to handle double-pinch gestures using the specified modes.
+    ///
+    /// ## Example
+    /// ```swift
+    /// Button("Tap Me") {
+    ///     print("Button tapped!")
+    /// }
+    /// .doublePinch()
+    /// ```
+    ///
+    /// - Note: If no action is found for the modifier, an error will be logged, and a fallback suggestion
+    ///   to access `.accessibilityQuickAction` directly will be provided.
+    ///
+    /// - Warning: Ensure the action for the button is properly configured. If not, a fault will be logged,
+    ///   and the action will not be executed.
+    ///
+    /// - Important: This method is marked as `@MainActor` to ensure that UI updates are performed on the main thread.
     @MainActor
     public func doublePinch(_ mode: DoublePinchMode = DoublePinchMode.automatic) -> some View {
         let modifier = DoublePinchViewModifier(mode: mode) {

--- a/Sources/DoublePinch/DoublePinchButton.swift
+++ b/Sources/DoublePinch/DoublePinchButton.swift
@@ -8,19 +8,14 @@ import WatchKit
 
 struct DoublePinchButton<Label: View>: View {
     
-    enum Mode {
-        case accessibilityQuickAction
-        case doubleTapGesture
-    }
-    
-    let mode: Mode
+    let mode: DoublePinchMode
     
     private let action: () -> Void
     private let label: () -> Label
     
     init(
-        mode: Mode = isDoubleTapGestureSupported ? .doubleTapGesture : .accessibilityQuickAction,
-        action: @escaping () -> Void,
+        mode: DoublePinchMode = .all,
+        action: @escaping @MainActor () -> Void,
         @ViewBuilder label: @escaping () -> Label
     ) {
         self.mode = mode
@@ -28,44 +23,8 @@ struct DoublePinchButton<Label: View>: View {
         self.label = label
     }
     
-    static var model: String {
-        var sysinfo = utsname()
-        uname(&sysinfo)
-        let machineMirror = Mirror(reflecting: sysinfo.machine)
-        let identifier = machineMirror.children.reduce("") { identifier, element in
-            guard let value = element.value as? Int8, value != 0 else { return identifier }
-            return identifier + String(UnicodeScalar(UInt8(value)))
-        }
-        return identifier
-    }
-    
-    static var isDoubleTapGestureSupported: Bool { // AKA isSeries9OrNewer
-        // https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt
-        guard let firstModelDigit = Int(String(describing: model.first)) else {
-            return false
-        }
-        return firstModelDigit >= 7
-    }
-    
     var body: some View {
-        // handGestureShortcut is watchOS 11 only? Why not 10.0? (release version for Series 9)
-        if #available(watchOS 11.0, *) {
-            Button(action: action) {
-                label()
-            }
-            .handGestureShortcut(.primaryAction, isEnabled: mode == .doubleTapGesture)
-            .accessibilityQuickAction(style: .outline) {
-                Button("Accessibility label", action: action)
-                    .disabled(mode == .doubleTapGesture)
-            }
-        } else {
-            Button(action: action) {
-                label()
-            }
-            .accessibilityQuickAction(style: .outline) {
-                Button("Accessibility label", action: action)
-                    .disabled(mode == .doubleTapGesture)
-            }
-        }
+        Button(action: action, label: label)
+            .doublePinch(mode)
     }
 }

--- a/Sources/DoublePinch/DoublePinchButton.swift
+++ b/Sources/DoublePinch/DoublePinchButton.swift
@@ -5,7 +5,32 @@
 
 import SwiftUI
 import WatchKit
-
+/// A wrapper around the standard ``SwiftUI/Button`` that responds to a double-pinch gesture, supporting different gesture modes.
+///
+/// Use `DoublePinchButton` to create a button that can trigger actions in response to a double-pinch gesture,
+/// such as accessibility quick actions or gestures available on newer Apple Watch models. This struct
+/// encapsulates the functionality of a standard SwiftUI `Button` while adding double-pinch gesture support.
+///
+/// - Generic Parameter:
+///   - `Label`: The type of the view that represents the label of the button.
+///
+/// ## Example
+/// ```swift
+/// DoublePinchButton(mode: .accessibilityQuickAction) {
+///     print("Action triggered!")
+/// } label: {
+///     Text("Double Pinch Me")
+/// }
+/// ```
+///
+/// - Parameters:
+///   - mode: The mode(s) defining the types of double-pinch actions to handle. Defaults to `.all`,
+///     which includes all supported modes for the current device.
+///   - action: The action to perform when the button is tapped or the double-pinch gesture is recognized.
+///     This action is executed on the main thread.
+///   - label: A view builder that provides the button's visual content.
+///
+/// - Note: The double-pinch gesture support is added via the `.doublePinch(_:)` modifier.
 struct DoublePinchButton<Label: View>: View {
     
     let mode: DoublePinchMode

--- a/Sources/DoublePinch/DoublePinchButton.swift
+++ b/Sources/DoublePinch/DoublePinchButton.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import WatchKit
+
 /// A wrapper around the standard ``SwiftUI/Button`` that responds to a double-pinch gesture, supporting different gesture modes.
 ///
 /// Use `DoublePinchButton` to create a button that can trigger actions in response to a double-pinch gesture,

--- a/Sources/DoublePinch/DoublePinchButton.swift
+++ b/Sources/DoublePinch/DoublePinchButton.swift
@@ -14,7 +14,7 @@ struct DoublePinchButton<Label: View>: View {
     private let label: () -> Label
     
     init(
-        mode: DoublePinchMode = .all,
+        mode: DoublePinchMode = DoublePinchMode.automatic,
         action: @escaping @MainActor () -> Void,
         @ViewBuilder label: @escaping () -> Label
     ) {

--- a/Sources/DoublePinch/DoublePinchMode.swift
+++ b/Sources/DoublePinch/DoublePinchMode.swift
@@ -52,12 +52,14 @@ private extension DoublePinchMode {
     /// is based on the device's model identifier.
     ///
     /// See a complete list of device models [here](https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt)
-    static var isDoubleTapGestureSupported: Bool { // AKA isSeries9OrNewer
-        // https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt
-        guard let firstModelDigit = Int(String(describing: model.first)) else {
+    static var isDoubleTapGestureSupported: Bool {
+        guard
+            let firstModelChar = model.first(where: \.isNumber),
+            let firstModelInt = Int(String(firstModelChar))
+        else {
             return false
         }
-        return firstModelDigit >= 7
+        return firstModelInt >= 7
     }
     
     /// Retrieves the model identifier of the device.

--- a/Sources/DoublePinch/DoublePinchMode.swift
+++ b/Sources/DoublePinch/DoublePinchMode.swift
@@ -5,16 +5,36 @@
 
 import Foundation
 
+/// A set of options representing different modes for handling the double tap (AKA double pinch) gesture on an Apple Watch.
+///
+/// The `DoublePinchMode` struct allows configuration of different action modes that can be triggered
+/// by gestures or accessibility features. It supports determining available options dynamically
+/// based on the device's capabilities.
 public enum DoublePinchMode: Sendable {
     
+    /// Represents the Accessibility Quick Action mode, available from watchOS 9.0 for the Series 4/SE and newer watch models.
     case accessibilityQuickAction
     
+    /// Represents the hand gesture shortcut for the primary action, available from watchOS 11.0 for the Series 9 and newer watch models.
+    ///
+    /// On watchOS, this is performed by double-tapping the thumb and index finger together.
+    ///
+    /// Equivalent to `.handGestureShortcut(.primaryAction)`
     @available(watchOS 11.0, *)
     case doubleTapGesture
 }
 
 extension DoublePinchMode {
     
+    /// The automatic mode determines the most appropriate mode for the double-tap gesture
+    /// based on the availability of APIs (`watchOS 11.0` and later) and the compatibility
+    /// of the device model (Apple Watch Series 9 or newer).
+    ///
+    /// - If the device supports the double-tap gesture (`watchOS 11.0+` and Series 9+),
+    ///   the `doubleTapGesture` mode is returned.
+    /// - Otherwise, the `accessibilityQuickAction` mode is used as a fallback.
+    ///
+    /// Use this property to dynamically adapt functionality to the user's device and OS.
     public static var automatic: DoublePinchMode {
         if #available(watchOS 11.0, *), DoublePinchMode.isDoubleTapGestureSupported {
             .doubleTapGesture
@@ -26,6 +46,12 @@ extension DoublePinchMode {
 
 private extension DoublePinchMode {
     
+    /// Indicates whether the device supports the double-tap gesture feature.
+    ///
+    /// The double-tap gesture is supported on Apple Watch Series 9/Ultra and newer. This determination
+    /// is based on the device's model identifier.
+    ///
+    /// See a complete list of device models [here](https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt)
     static var isDoubleTapGestureSupported: Bool { // AKA isSeries9OrNewer
         // https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt
         guard let firstModelDigit = Int(String(describing: model.first)) else {
@@ -34,6 +60,9 @@ private extension DoublePinchMode {
         return firstModelDigit >= 7
     }
     
+    /// Retrieves the model identifier of the device.
+    ///
+    /// This value is used internally to determine device capabilities.
     static var model: String {
         var sysinfo = utsname()
         uname(&sysinfo)

--- a/Sources/DoublePinch/DoublePinchMode.swift
+++ b/Sources/DoublePinch/DoublePinchMode.swift
@@ -1,0 +1,47 @@
+//
+//  DoublePinchMode.swift
+//  DoublePinch
+//
+
+import Foundation
+
+public enum DoublePinchMode: Sendable {
+    
+    case accessibilityQuickAction
+    
+    @available(watchOS 11.0, *)
+    case doubleTapGesture
+}
+
+extension DoublePinchMode {
+    
+    public static var automatic: DoublePinchMode {
+        if #available(watchOS 11.0, *), DoublePinchMode.isDoubleTapGestureSupported {
+            .doubleTapGesture
+        } else {
+            .accessibilityQuickAction
+        }
+    }
+}
+
+private extension DoublePinchMode {
+    
+    static var isDoubleTapGestureSupported: Bool { // AKA isSeries9OrNewer
+        // https://gist.github.com/adamawolf/3048717#file-apple_mobile_device_types-txt
+        guard let firstModelDigit = Int(String(describing: model.first)) else {
+            return false
+        }
+        return firstModelDigit >= 7
+    }
+    
+    static var model: String {
+        var sysinfo = utsname()
+        uname(&sysinfo)
+        let machineMirror = Mirror(reflecting: sysinfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        return identifier
+    }
+}

--- a/TappableButton/Package.swift
+++ b/TappableButton/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TappableButton",
+    platforms: [.watchOS(.v9)],
+    products: [
+        .library(name: "TappableButton", targets: ["TappableButton"]),
+    ],
+    targets: [
+        .target(name: "TappableButton"),
+    ]
+)

--- a/TappableButton/Sources/TappableButton/TappableButton.swift
+++ b/TappableButton/Sources/TappableButton/TappableButton.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension Button {
+    
+    public var _action: (@MainActor () -> Void)? {
+        guard let action = Mirror(reflecting: self).descendant("action") else {
+            return nil
+        }
+        
+        guard let closure = Mirror(reflecting: action).descendant("closure") else {
+            return nil
+        }
+        
+        return closure as? (@MainActor () -> Void)
+    }
+}

--- a/TappableButton/Sources/TappableButton/TappableButton.swift
+++ b/TappableButton/Sources/TappableButton/TappableButton.swift
@@ -22,7 +22,7 @@ extension Button {
         }
         
         guard let closure = Mirror(reflecting: action).descendant("closure") else {
-            return nil
+            return action as? T
         }
         
         return closure as? T

--- a/TappableButton/Sources/TappableButton/TappableButton.swift
+++ b/TappableButton/Sources/TappableButton/TappableButton.swift
@@ -2,7 +2,21 @@ import SwiftUI
 
 extension Button {
     
-    public var _action: (@MainActor () -> Void)? {
+    public func _performAction() -> Bool {
+        if #available(watchOS 11.0, *), let action = getAction((@MainActor () -> Void).self) {
+            MainActor.assumeIsolated(action)
+            return true
+        }
+        
+        if let action = getAction((() -> Void).self) {
+            action()
+            return true
+        }
+        
+        return false
+    }
+    
+    private func getAction<T>(_ type: T.Type) -> T? {
         guard let action = Mirror(reflecting: self).descendant("action") else {
             return nil
         }
@@ -11,6 +25,6 @@ extension Button {
             return nil
         }
         
-        return closure as? (@MainActor () -> Void)
+        return closure as? T
     }
 }

--- a/Tests/DoublePinchTests/TappableButtonTests.swift
+++ b/Tests/DoublePinchTests/TappableButtonTests.swift
@@ -9,13 +9,25 @@ import Testing
 
 struct TappableButtonTests {
     
-    @MainActor
-    @Test("Action can be performed programmatically", .timeLimit(.minutes(1)))
-    func performAction() async throws {
-        try await confirmation { confirm in
+    @Test("Action can be performed programmatically starting from watchOS 11.0", .timeLimit(.minutes(1)))
+    @available(watchOS 11.0, *)
+    @MainActor func performAction() async throws {
+        try await assertAction()
+    }
+    
+    @Test("Action can be performed programmatically before watchOS 11.0", .timeLimit(.minutes(1)))
+    @available(watchOS, obsoleted: 11.0)
+    func performAction2() async throws {
+        try await assertAction()
+    }
+}
+
+private extension TappableButtonTests {
+    
+    @MainActor private func assertAction() async throws {
+        await confirmation { confirm in
             let button = SwiftUI.Button("") { confirm() }
-            let action = try #require(button._action)
-            action()
+            #expect(button._performAction() == true)
         }
     }
 }

--- a/Tests/DoublePinchTests/TappableButtonTests.swift
+++ b/Tests/DoublePinchTests/TappableButtonTests.swift
@@ -1,0 +1,21 @@
+//
+//  TappableButtonTests.swift
+//  DoublePinch
+//
+
+import SwiftUI
+import TappableButton
+import Testing
+
+struct TappableButtonTests {
+    
+    @MainActor
+    @Test("Action can be performed programmatically", .timeLimit(.minutes(1)))
+    func performAction() async throws {
+        try await confirmation { confirm in
+            let button = SwiftUI.Button("") { confirm() }
+            let action = try #require(button._action)
+            action()
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces new functionality to the `DoublePinch` package by adding a dependency on the `TappableButton` package. It also refactors the `DoublePinch` code to use a new `DoublePinchMode` option set and updates the button implementation accordingly. Additionally, a new `TappableButton` package is created, and tests are added for the new functionality.

### New functionality and dependencies:

* [`Package.swift`](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR12-R17): Added `TappableButton` as a dependency and updated the `DoublePinch` target to include `TappableButton`. Also added a new test target `DoublePinchTests`.

### Code refactoring and improvements:

* [`Sources/DoublePinch/DoublePinch.swift`](diffhunk://#diff-17223d4adfe8e0925484183ab62ff332334dbd305a9b7d89c10bc75451e91856R1-R105): Introduced `DoublePinchMode` option set, which includes accessibility quick action and double-tap gesture modes. Refactored the `doublePinch` method to use this new option set and added a `DoublePinchViewModifier` for handling the pinch actions.

* [`Sources/DoublePinch/DoublePinchButton.swift`](diffhunk://#diff-db52b803b468dfed3bb6b4d92184a268fb61fbaae8c6875524914c1e29adc066L11-R28): Refactored to use the new `DoublePinchMode` option set and simplified the button implementation by using the `doublePinch` method. Removed redundant code for model detection and gesture support.

### New package creation:

* [`TappableButton/Package.swift`](diffhunk://#diff-17c8b19c1670c55a3c7c220f8adb93e44ca2e2f82e2c2cd930553ede409ed755R1-R15): Created a new Swift package `TappableButton` with support for watchOS 9 and added it as a library product. `TappableButton` uses swift-tools-version 5.10 to resolve a casting problem of `@MainActor () -> Void` to `@MainActor @Sendable () -> Void` in Swift 6.
For more information:
- https://forums.swift.org/t/is-there-any-real-difference-between-mainactor-sendable-and-mainactor/72525
- https://github.com/swiftlang/swift/issues/75683

* [`TappableButton/Sources/TappableButton/TappableButton.swift`](diffhunk://#diff-29e6e4c06a489a87c37ab0e7c216d593e9a24668b2c29d18b8789803507706cfR1-R16): Added an extension to `Button` to expose the internal action closure, enabling programmatic action triggering.

### Tests:

* [`Tests/DoublePinchTests/TappableButtonTests.swift`](diffhunk://#diff-2342891bb670bf42637a630a72b994b881bd0b1009524b2de6f9fd7ca61af1beR1-R21): Added tests for the `TappableButton` package to ensure that actions can be performed programmatically.