### PR TITLE
1.0.0

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,32 @@
+name: "\U0001F9E9 Build Package"
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Configure watchOS simulator build settings
+        run: |
+          echo "WATCH_SIMULATOR_SDK=$(xcrun --sdk watchsimulator --show-sdk-path)" >> "$GITHUB_ENV"
+          echo "WATCH_SIMULATOR_TRIPLE=$(uname -m)-apple-watchos9.0-simulator" >> "$GITHUB_ENV"
+
+      - name: Build TappableButton target
+        run: |
+          swift build \
+            --target TappableButton \
+            --triple "$WATCH_SIMULATOR_TRIPLE" \
+            --sdk "$WATCH_SIMULATOR_SDK"
+
+      - name: Build DoublePinch target
+        run: |
+          swift build \
+            --target DoublePinch \
+            --triple "$WATCH_SIMULATOR_TRIPLE" \
+            --sdk "$WATCH_SIMULATOR_SDK"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# DoublePinch
+
+`DoublePinch` adds double-pinch support to SwiftUI `Button`s on watchOS.
+
+On supported Apple Watch models running watchOS 11 or newer, it uses the system hand gesture shortcut for the primary action. On earlier supported devices, it falls back to an accessibility quick action so the same button can still participate in a double-pinch driven flow.
+
+## Requirements
+
+- watchOS 9.0+
+- Xcode 16+
+- Swift 6
+
+## Installation
+
+Add the package from the repository URL:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/superturboryan/DoublePinch.git", from: "1.0.0"),
+]
+```
+
+Then add `DoublePinch` to your target dependencies:
+
+```swift
+.target(
+    name: "MyWatchApp",
+    dependencies: [
+        .product(name: "DoublePinch", package: "DoublePinch"),
+    ]
+)
+```
+
+## Usage
+
+Import the package and apply `.doublePinch()` to a SwiftUI `Button`:
+
+```swift
+import DoublePinch
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Button("Start Workout") {
+            startWorkout()
+        }
+        .doublePinch()
+    }
+
+    private func startWorkout() {
+        // Trigger your primary action here.
+    }
+}
+```
+
+### Choosing a mode
+
+`DoublePinch` exposes these configuration options through `DoublePinchMode`:
+
+- `.automatic`
+- `.accessibilityQuickAction`
+- `.doubleTapGesture` on watchOS 11+
+
+On watchOS 11 and newer, `.automatic` upgrades to the system double-tap gesture when the hardware supports it. Otherwise it uses the accessibility quick action fallback.
+
+In most cases, `.automatic` is the right default.
+
+If you want to force the fallback behavior:
+
+```swift
+Button("Confirm") {
+    confirm()
+}
+.doublePinch(.accessibilityQuickAction)
+```
+
+If you specifically want to choose the mode yourself, provide an explicit fallback:
+
+```swift
+if #available(watchOS 11.0, *) {
+    Button("Pay") {
+        submitPayment()
+    }
+    .doublePinch(.doubleTapGesture)
+} else {
+    Button("Pay") {
+        submitPayment()
+    }
+    .doublePinch(.accessibilityQuickAction)
+}
+```
+
+## How it works
+
+- `Button.doublePinch()` attaches the package's gesture-aware view modifier.
+- `.automatic` chooses between `handGestureShortcut(.primaryAction)` and `accessibilityQuickAction(style: .outline)` based on OS support and device capability.
+- Explicit modes do exactly what you request, so use `.doubleTapGesture` only when you want the watchOS 11 gesture path.
+- The current implementation reuses the button's primary action by introspecting the underlying `Button`, so it is worth validating on the watchOS versions and button styles you ship.
+
+## License
+
+`DoublePinch` is available under the MIT license. See [LICENSE.txt](LICENSE.txt).


### PR DESCRIPTION
## Summary
- adds a repository README for DoublePinch (closes #2)
   - document installation, requirements, usage, and mode selection
   - clarify the current implementation details and explicit fallback behavior
- prepares the repository for its initial release
- adds a GH action to build the package

## Validation
- `swift test` was run locally using watchOS target

## Follow-up
- once this README work is merged, the release plan is to add a `1.0.0` tag and submit the package to [Swift Package Index](https://swiftpackageindex.com/)